### PR TITLE
Step9 Web のフロントエンドを実装する

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -205,7 +205,6 @@ def get_item(item_id: int, db: sqlite3.Connection = Depends(get_db)):
     return dict(row)
 
 
-# GET-/image/{image_name} リクエストで呼び出され、指定された画像を返す
 @app.get("/image/{item_id}.jpg")
 async def get_image_by_item_id(item_id: int, db: sqlite3.Connection = Depends(get_db)):
     # DB から item_id に対応する image_name を取得する

--- a/python/main.py
+++ b/python/main.py
@@ -26,12 +26,14 @@ def get_db():
     if not db_path.exists():
         yield
 
-    conn = sqlite3.connect(db_path)
+    # check_same_thread=False を追加
+    conn = sqlite3.connect(db_path, check_same_thread=False)
     conn.row_factory = sqlite3.Row  # Return rows as dictionaries
     try:
         yield conn
     finally:
         conn.close()
+
 
 
 # STEP 5-1: set up the database connection
@@ -173,7 +175,7 @@ def get_items(db: sqlite3.Connection = Depends(get_db)):
                             items.id AS id, 
                             items.name AS name, 
                             categories.name AS category, 
-                            items.image_name AS items_name 
+                            items.image_name AS image_name 
                         FROM items
                         JOIN categories
                         ON items.category_id = categories.id
@@ -204,19 +206,24 @@ def get_item(item_id: int, db: sqlite3.Connection = Depends(get_db)):
 
 
 # GET-/image/{image_name} リクエストで呼び出され、指定された画像を返す
-@app.get("/image/{image_name}")
-async def get_image(image_name: str):
-    # 画像ファイルのパスを生成する
+@app.get("/image/{item_id}.jpg")
+async def get_image_by_item_id(item_id: int, db: sqlite3.Connection = Depends(get_db)):
+    # DB から item_id に対応する image_name を取得する
+    cursor = db.execute("SELECT image_name FROM items WHERE id = ?", (item_id,))
+    row = cursor.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Item not found")
+    
+    image_name = row["image_name"]
     image_file_path = images / image_name
 
-    if not image_name.endswith(".jpg"):
-        raise HTTPException(status_code=400, detail="Image path does not end with .jpg")
-
+    # 画像ファイルが存在しなければデフォルト画像を返す
     if not image_file_path.exists():
         logger.debug(f"Image not found: {image_file_path}")
         image_file_path = images / "default.jpg"
 
     return FileResponse(image_file_path)
+
 
 
 

--- a/typescript/simple-mercari-web/src/App.css
+++ b/typescript/simple-mercari-web/src/App.css
@@ -1,18 +1,37 @@
+/* すべての要素の余白をリセット */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* body 全体を背景色 #222427 に */
+html, body {
+  margin: 0;
+  padding: 0;
+  background-color: #222427; /* 全体背景を指定したい場合 */
+}
+
+/* App コンテナ */
 .App {
+  width: 100%;
+  min-height: 100vh;
   text-align: center;
 }
 
+/* タイトルやフォームなどのヘッダ部分 */
 .Title {
   background-color: #222427;
   min-height: 8vh;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: left;
+  align-items: center;      /* 縦方向の中央寄せ */
+  justify-content: center;  /* 横方向の中央寄せ */
   font-size: calc(10px + 1vmin);
   color: white;
 }
 
+
+/* リスト投稿フォーム部分 */
 .Listing {
   background-color: #222427;
   min-height: 8vh;
@@ -24,9 +43,9 @@
   color: white;
 }
 
+/* 個々のアイテム枠 */
 .ItemList {
   background-color: #222427;
-  min-height: 8vh;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -35,15 +54,24 @@
   color: white;
 }
 
-.App-link {
-  color: #61dafb;
+/* グリッドコンテナ */
+.ItemsGrid {
+  /* 横幅いっぱいに広げる */
+  width: 100%;
+  display: grid;
+  /* デフォルトは 1 列表示 */
+  grid-template-columns: 1fr;
+
+  /* アイテム同士の隙間 */
+  gap: 1rem;
+  /* コンテナ内側の余白 */
+  padding: 1rem;
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
+/* 画面幅が 624px 以上になったら 3 列にする */
+@media screen and (min-width: 624px) {
+  .ItemsGrid {
+    grid-template-columns: repeat(3, 1fr);
   }
 }
+

--- a/typescript/simple-mercari-web/src/components/ItemList.tsx
+++ b/typescript/simple-mercari-web/src/components/ItemList.tsx
@@ -29,20 +29,25 @@ export const ItemList = ({ reload, onLoadCompleted }: Prop) => {
   }, [reload, onLoadCompleted]);
 
   return (
-    <div>
-      {items?.map((item) => {
-        return (
-          <div key={item.id} className="ItemList">
-            {/* TODO: Task 2: Show item images */}
-            <img src={`http://localhost:9000/image/${item.id}.jpg`} alt={item.name} />
-            <p>
-              <span>Name: {item.name}</span>
-              <br />
-              <span>Category: {item.category}</span>
-            </p>
-          </div>
-        );
-      })}
+    <div className="ItemsGrid">
+      {items?.map((item) => (
+        <div key={item.id} className="ItemList">
+          <img
+            src={`http://localhost:9000/image/${item.id}.jpg`}
+            alt={item.name}
+            style={{
+              width: "150px",
+              height: "150px",
+              objectFit: "cover"
+            }}
+          />
+          <p>
+            <span>Name: {item.name}</span>
+            <br />
+            <span>Category: {item.category}</span>
+          </p>
+        </div>
+      ))}
     </div>
-  );
+  );  
 };

--- a/typescript/simple-mercari-web/src/components/ItemList.tsx
+++ b/typescript/simple-mercari-web/src/components/ItemList.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Item, fetchItems } from '~/api';
 
-const PLACEHOLDER_IMAGE = import.meta.env.VITE_FRONTEND_URL + '/logo192.png';
+// const PLACEHOLDER_IMAGE = import.meta.env.VITE_FRONTEND_URL + '/logo192.png';
 
 interface Prop {
   reload: boolean;
@@ -34,7 +34,7 @@ export const ItemList = ({ reload, onLoadCompleted }: Prop) => {
         return (
           <div key={item.id} className="ItemList">
             {/* TODO: Task 2: Show item images */}
-            <img src={PLACEHOLDER_IMAGE} />
+            <img src={`http://localhost:9000/image/${item.id}.jpg`} alt={item.name} />
             <p>
               <span>Name: {item.name}</span>
               <br />

--- a/typescript/simple-mercari-web/src/components/Listing.tsx
+++ b/typescript/simple-mercari-web/src/components/Listing.tsx
@@ -103,3 +103,108 @@ export const Listing = ({ onListingCompleted }: Prop) => {
     </div>
   );
 };
+
+// ↑ 画像の入力もmust
+// ↓ 画像の入力をOptionalにする
+// import { useRef, useState } from 'react';
+// import { postItem } from '~/api';
+
+// interface Prop {
+//   onListingCompleted: () => void;
+// }
+
+// type FormDataType = {
+//   name: string;
+//   category: string;
+//   image: string | File;
+// };
+
+// export const Listing = ({ onListingCompleted }: Prop) => {
+//   const initialState: FormDataType = {
+//     name: '',
+//     category: '',
+//     image: '',
+//   };
+//   const [values, setValues] = useState<FormDataType>(initialState);
+
+//   const uploadImageRef = useRef<HTMLInputElement>(null);
+
+//   const onValueChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+//     setValues({
+//       ...values,
+//       [event.target.name]: event.target.value,
+//     });
+//   };
+
+//   const onFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+//     setValues({
+//       ...values,
+//       [event.target.name]: event.target.files ? event.target.files[0] : '',
+//     });
+//   };
+
+//   const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+//     event.preventDefault();
+
+//     // バリデーション: 必須は "name" のみ
+//     if (!values.name) {
+//       alert('Missing field: name');
+//       return;
+//     }
+
+//     // Submit the form
+//     postItem({
+//       name: values.name,
+//       category: values.category,
+//       image: values.image,
+//     })
+//       .then(() => {
+//         alert('Item listed successfully');
+//       })
+//       .catch((error) => {
+//         console.error('POST error:', error);
+//         alert('Failed to list this item');
+//       })
+//       .finally(() => {
+//         onListingCompleted();
+//         setValues(initialState);
+//         if (uploadImageRef.current) {
+//           uploadImageRef.current.value = '';
+//         }
+//       });
+//   };
+
+//   return (
+//     <div className="Listing">
+//       <form onSubmit={onSubmit}>
+//         <div>
+//           <input
+//             type="text"
+//             name="name"
+//             id="name"
+//             placeholder="name"
+//             onChange={onValueChange}
+//             required
+//             value={values.name}
+//           />
+//           <input
+//             type="text"
+//             name="category"
+//             id="category"
+//             placeholder="category"
+//             onChange={onValueChange}
+//             value={values.category}
+//           />
+//           <input
+//             type="file"
+//             name="image"
+//             id="image"
+//             onChange={onFileChange}
+//             ref={uploadImageRef}
+//           />
+//           <button type="submit">List this item</button>
+//         </div>
+//       </form>
+//     </div>
+//   );
+// };


### PR DESCRIPTION
## What
<!--- Write the change being made with this pull request --->
- [x] webのフロントエンドの環境構築
- [x] 課題 1. 新しい商品を登録する
- [x] 課題 2. 各アイテムの画像を表示する
- [x] 課題 3. HTML と CSS を使ってスタイルを変更する
- バラバラの画像のサイズを統一して表示されるようにした
- ウィンドウ内の余白を背景色で塗りつぶした
- [x] 課題 4. アイテム一覧の UI を変更する
- 三列表示で見やすくした。
- ウィンドウサイズが小さい時は１列になるようにした。

## Result
↓レスポンシブ対応で、ウィンドウ幅が小さい時は一列、幅が大きい時は三列になるようにした。
<img width="581" alt="スクリーンショット 2025-03-14 0 50 29" src="https://github.com/user-attachments/assets/5f58190d-c866-4b91-8e0c-1a62aff32920" />

<img width="722" alt="スクリーンショット 2025-03-14 0 50 13" src="https://github.com/user-attachments/assets/4320ce6a-eb1e-453c-b7fe-72f31811926e" />


## CHECKS :warning:

Please make sure you are aware of the following.

- [x] **The changes in this PR doesn't have private information
